### PR TITLE
Progress badge

### DIFF
--- a/src/Checklists/Checklist/Progress.tsx
+++ b/src/Checklists/Checklist/Progress.tsx
@@ -11,7 +11,6 @@ const ChecklistProgressContainer = styled.div`
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  margin: 16px 0px 12px 0px;
 `
 const ChecklistProgressProgressBar = styled.div`
   flex-grow: 1;
@@ -57,33 +56,38 @@ export const ProgressBar = ({
   total,
   fillColor = PROGRESS_BAR_COLOR_STYLES.fillColor,
   display = 'count',
+  style = {}
 }: {
   count: number
   total: number
   fillColor?: string
-  display?: 'count' | 'percent'
+  display?: 'count' | 'percent' | 'compact',
+  style?: CSSProperties
 }) => {
   if (total === 0) return <></>
 
   const fgWidth = count === 0 ? '10px' : `${(count / total) * 100}%`
+  const barHeight = display === 'compact' ? '5px' : '10px'
+  const percentComplete = Math.round((count / total) * 100)
 
   let stepText
   if (display === 'count') {
     stepText = `${count} of ${total}`
+  } else if (display === 'compact') {
+    stepText = `${percentComplete}%`
   } else if (display === 'percent') {
-    const percentComplete = Math.round((count / total) * 100)
     stepText = `${percentComplete}% complete`
   }
 
   return (
-    <ChecklistProgressContainer>      
+    <ChecklistProgressContainer style={style}>      
       <StepText>{stepText}</StepText>
       <ChecklistProgressProgressBar>
         <div
           className="ProgressBarFGFill"
-          style={{ ...progressFgStyle, width: fgWidth, backgroundColor: fillColor }}
+          style={{ ...progressFgStyle, width: fgWidth, height: barHeight, backgroundColor: fillColor }}
         />
-        <div style={progressBgStyle} />
+        <div style={{ ...progressBgStyle, height: barHeight }} />
       </ChecklistProgressProgressBar>
     </ChecklistProgressContainer>
   )

--- a/src/Checklists/Checklist/Progress.tsx
+++ b/src/Checklists/Checklist/Progress.tsx
@@ -83,7 +83,7 @@ export const ProgressBar = ({
   }
 
   return (
-    <ChecklistProgressContainer style={style}>      
+    <ChecklistProgressContainer style={style}>
       <StepText style={textStyle} padding={padding}>{stepText}</StepText>
       <ChecklistProgressProgressBar>
         <div

--- a/src/Checklists/Checklist/Progress.tsx
+++ b/src/Checklists/Checklist/Progress.tsx
@@ -17,21 +17,19 @@ const ChecklistProgressProgressBar = styled.div`
   position: relative;
 `
 
-const StepText = styled.p`
+const StepText = styled.p<{padding}>`
   font-weight: 600;
   font-size: 15px;
   line-height: 18px;
-  min-width: 130px;
-  padding-right: 20px;
+  padding-right: ${props => props.padding};
 `
 
 const progressBgStyle: CSSProperties = {
   position: 'relative',
   left: 0,
   top: 0,
-  backgroundColor: PROGRESS_BAR_COLOR_STYLES.backgroundColor,
   width: '100%',
-  minWidth: '12px',
+  minWidth: '40px',
   height: '10px',
   borderRadius: '20px',
 }
@@ -55,20 +53,25 @@ export const ProgressBar = ({
   count,
   total,
   fillColor = PROGRESS_BAR_COLOR_STYLES.fillColor,
+  bgColor = PROGRESS_BAR_COLOR_STYLES.backgroundColor,
   display = 'count',
-  style = {}
+  style = {},
+  textStyle = {}
 }: {
   count: number
   total: number
   fillColor?: string
+  bgColor?: string
   display?: 'count' | 'percent' | 'compact',
   style?: CSSProperties
+  textStyle?: CSSProperties
 }) => {
   if (total === 0) return <></>
 
   const fgWidth = count === 0 ? '10px' : `${(count / total) * 100}%`
   const barHeight = display === 'compact' ? '5px' : '10px'
   const percentComplete = Math.round((count / total) * 100)
+  const padding = display === 'compact' ? '5px' : '20px'
 
   let stepText
   if (display === 'count') {
@@ -81,13 +84,13 @@ export const ProgressBar = ({
 
   return (
     <ChecklistProgressContainer style={style}>      
-      <StepText>{stepText}</StepText>
+      <StepText style={textStyle} padding={padding}>{stepText}</StepText>
       <ChecklistProgressProgressBar>
         <div
           className="ProgressBarFGFill"
           style={{ ...progressFgStyle, width: fgWidth, height: barHeight, backgroundColor: fillColor }}
         />
-        <div style={{ ...progressBgStyle, height: barHeight }} />
+        <div style={{ ...progressBgStyle, height: barHeight, backgroundColor: bgColor }} />
       </ChecklistProgressProgressBar>
     </ChecklistProgressContainer>
   )

--- a/src/Checklists/Checklist/__tests__/Progress.test.tsx
+++ b/src/Checklists/Checklist/__tests__/Progress.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { ProgressBar } from '../Progress'
+
+describe('ProgressBar', () => {
+
+  const progressBarProps = {
+    count: 2,
+    total: 10
+  }
+
+  describe("compact", () => {
+    test("renders as expected", () => {
+      render(<ProgressBar {...progressBarProps} display='compact'/>)
+    })
+    // expect(screen.getByText('20%')).toBeDefined();
+  })
+  describe("percent", () => {
+    test("renders as expected", () => {
+      render(<ProgressBar {...progressBarProps} display='percent'/>)
+    })
+    expect(screen.getByText('20% complete')).toBeDefined();
+  })
+  describe("count", () => {
+    test("renders as expected", () => {
+      render(<ProgressBar {...progressBarProps} display='count'/>)
+    })
+    expect(screen.getByText('2 of 10')).toBeDefined();
+  })
+})

--- a/src/Checklists/Checklist/__tests__/Progress.test.tsx
+++ b/src/Checklists/Checklist/__tests__/Progress.test.tsx
@@ -18,13 +18,13 @@ describe('ProgressBar', () => {
   describe("percent", () => {
     test("renders as expected", () => {
       render(<ProgressBar {...progressBarProps} display='percent'/>)
+      expect(screen.getByText('20% complete')).toBeDefined();
     })
-    expect(screen.getByText('20% complete')).toBeDefined();
   })
   describe("count", () => {
     test("renders as expected", () => {
       render(<ProgressBar {...progressBarProps} display='count'/>)
+      expect(screen.getByText('2 of 10')).toBeDefined();
     })
-    expect(screen.getByText('2 of 10')).toBeDefined();
   })
 })

--- a/src/Checklists/HeroChecklist/HeroChecklist.tsx
+++ b/src/Checklists/HeroChecklist/HeroChecklist.tsx
@@ -154,7 +154,7 @@ const HeroChecklist: FC<HeroChecklistProps> = ({
         <ChecklistHeader style={{ padding: '30px 0px 30px 30px', borderBottom: 'none' }}>
           <HeroChecklistTitle>{title}</HeroChecklistTitle>
           <HeroChecklistSubtitle>{subtitle}</HeroChecklistSubtitle>
-          <ProgressBar total={steps.length} count={completeCount} fillColor={primaryColor} />
+          <ProgressBar total={steps.length} count={completeCount} fillColor={primaryColor} style={{ marginTop: '24px' }}/>
         </ChecklistHeader>
         <ChecklistStepsContainer>
           {steps.map((s: StepData, idx: number) => {

--- a/src/Checklists/ModalChecklist/ModalChecklist.tsx
+++ b/src/Checklists/ModalChecklist/ModalChecklist.tsx
@@ -75,6 +75,7 @@ const ModalChecklist: FC<ModalChecklistProps> = ({
               count={completeCount}
               total={steps.length}
               fillColor={primaryColor}
+              style={{ marginTop: '24px' }}
             />
           </>
         }

--- a/src/Checklists/ProgressBadge/__tests__/ProgressBadge.test.tsx
+++ b/src/Checklists/ProgressBadge/__tests__/ProgressBadge.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ProgressBadge from '..'
+import { ProgressBadge } from '..'
 import { render, screen, fireEvent } from '@testing-library/react'
 
 describe('ChecklistProgressBadge', () => {

--- a/src/Checklists/ProgressBadge/__tests__/ProgressBadge.test.tsx
+++ b/src/Checklists/ProgressBadge/__tests__/ProgressBadge.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import ProgressBadge from '..'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+describe('ChecklistProgressBadge', () => {
+  const checklistProgressProps = {
+    title: 'Test Checklist',
+    onClick: jest.fn(),
+    count: 2,
+    total: 10,
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('renders', () => {
+    render(<ProgressBadge {...checklistProgressProps} />)
+    expect(screen.getByText(checklistProgressProps.title)).toBeDefined()
+    expect(screen.getByText('20%')).toBeDefined()
+  })
+
+  test('calls onClick on clicking', () => {
+    render(<ProgressBadge {...checklistProgressProps} />)
+    fireEvent.click(screen.getByText(checklistProgressProps.title))
+    expect(checklistProgressProps.onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/Checklists/ProgressBadge/index.tsx
+++ b/src/Checklists/ProgressBadge/index.tsx
@@ -1,0 +1,38 @@
+import React, { CSSProperties, FC } from 'react'
+import { Chevron } from '../../components/Icons/Chevron'
+import { ProgressBar } from '../Checklist/Progress'
+import { BadgeContainer, BadgeRow, BadgeTitle } from './styled'
+
+interface ProgressBadgeProps {
+  title: string
+  count: number
+  total: number
+  style?: CSSProperties
+  textStyle?: CSSProperties
+  onClick: () => void
+}
+
+const ProgressBadge: FC<ProgressBadgeProps> = ({
+  title,
+  count,
+  total,
+  onClick,
+  style = {},
+  textStyle = {},
+}) => {
+  return (
+    <BadgeContainer onClick={() => onClick !== undefined && onClick()} style={style}>
+      <BadgeRow>
+        <BadgeTitle style={textStyle}>{title}</BadgeTitle>
+        <Chevron />
+      </BadgeRow>
+      <BadgeRow>
+        {total && total !== 0 && (
+          <ProgressBar display="compact" count={count} total={total}></ProgressBar>
+        )}
+      </BadgeRow>
+    </BadgeContainer>
+  )
+}
+
+export default ProgressBadge

--- a/src/Checklists/ProgressBadge/index.tsx
+++ b/src/Checklists/ProgressBadge/index.tsx
@@ -10,29 +10,33 @@ interface ProgressBadgeProps {
   style?: CSSProperties
   textStyle?: CSSProperties
   onClick: () => void
+  primaryColor?: string
+  secondaryColor?: string
 }
 
-const ProgressBadge: FC<ProgressBadgeProps> = ({
+export const ProgressBadge: FC<ProgressBadgeProps> = ({
   title,
   count,
   total,
   onClick,
   style = {},
   textStyle = {},
+  primaryColor = '#000000',
+  secondaryColor = '#E6E6E6'
 }) => {
   return (
     <BadgeContainer onClick={() => onClick !== undefined && onClick()} style={style}>
       <BadgeRow>
         <BadgeTitle style={textStyle}>{title}</BadgeTitle>
-        <Chevron />
+        {
+          onClick !== undefined && (
+            <Chevron color={primaryColor} />
+          )
+        }
       </BadgeRow>
-      <BadgeRow>
-        {total && total !== 0 && (
-          <ProgressBar display="compact" count={count} total={total}></ProgressBar>
-        )}
-      </BadgeRow>
+      {total && total !== 0 && (
+        <ProgressBar display="compact" count={count} total={total} fillColor={primaryColor} bgColor={secondaryColor} textStyle={textStyle} style={{ width: '100%'}}/>
+      )}
     </BadgeContainer>
   )
 }
-
-export default ProgressBadge

--- a/src/Checklists/ProgressBadge/styled.ts
+++ b/src/Checklists/ProgressBadge/styled.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components'
+
+export const BadgeContainer = styled.div<{ primaryColor }>`
+  background-color: ${(props) => props.primaryColor};
+  border: 1px solid ${(props) => props.primaryColor};
+  border-radius: 8px;
+  margin: 10px;
+  padding: 10px 12px 10px 12px;
+`
+
+export const BadgeRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`
+
+export const BadgeTitle = styled.p<{ color }>`
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 15px;
+  color: ${(props) => props.color};
+`

--- a/src/Checklists/ProgressBadge/styled.ts
+++ b/src/Checklists/ProgressBadge/styled.ts
@@ -1,11 +1,11 @@
 import styled from 'styled-components'
 
-export const BadgeContainer = styled.div<{ primaryColor }>`
-  background-color: ${(props) => props.primaryColor};
+export const BadgeContainer = styled.div<{primaryColor}>`
   border: 1px solid ${(props) => props.primaryColor};
   border-radius: 8px;
   margin: 10px;
   padding: 10px 12px 10px 12px;
+  min-width: 160px;
 `
 
 export const BadgeRow = styled.div`
@@ -13,6 +13,7 @@ export const BadgeRow = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+  margin-bottom: 4px;
 `
 
 export const BadgeTitle = styled.p<{ color }>`

--- a/src/FrigadeProgressBadge/index.tsx
+++ b/src/FrigadeProgressBadge/index.tsx
@@ -1,0 +1,37 @@
+import React, { CSSProperties } from 'react'
+import { useFlows } from '../api/flows';
+import { ProgressBadge } from "../Checklists/ProgressBadge";
+
+interface FrigadeProgressBadgeProps {
+  flowId: string
+  title: string
+  style?: CSSProperties
+  primaryColor?: string
+  secondaryColor?: string
+  textStyle?: CSSProperties
+  onClick?: () => void
+}
+
+export const FrigadeProgressBadge: React.FC<FrigadeProgressBadgeProps> = ({ flowId, primaryColor, title, style, textStyle, secondaryColor, onClick }) => {
+
+  const {
+    getFlow,
+    getFlowSteps,
+    getNumberOfStepsCompleted,
+    isLoading,
+  } = useFlows()
+
+  if (isLoading) {
+    return null
+  }
+
+  const flow = getFlow(flowId)
+  if (!flow) {
+    return null
+  }
+
+  const steps = getFlowSteps(flowId)
+  const completedCount = getNumberOfStepsCompleted(flowId)
+
+  return <ProgressBadge count={completedCount} total={steps.length} title={title} style={style} primaryColor={primaryColor} secondaryColor={secondaryColor} textStyle={textStyle} onClick={onClick} />
+}

--- a/src/FrigadeProgressBadge/index.tsx
+++ b/src/FrigadeProgressBadge/index.tsx
@@ -33,5 +33,16 @@ export const FrigadeProgressBadge: React.FC<FrigadeProgressBadgeProps> = ({ flow
   const steps = getFlowSteps(flowId)
   const completedCount = getNumberOfStepsCompleted(flowId)
 
-  return <ProgressBadge count={completedCount} total={steps.length} title={title} style={style} primaryColor={primaryColor} secondaryColor={secondaryColor} textStyle={textStyle} onClick={onClick} />
+  return (
+    <ProgressBadge
+      count={completedCount}
+      total={steps.length}
+      title={title}
+      style={style}
+      primaryColor={primaryColor}
+      secondaryColor={secondaryColor}
+      textStyle={textStyle}
+      onClick={onClick}
+    />
+  )
 }

--- a/src/components/Icons/Chevron.tsx
+++ b/src/components/Icons/Chevron.tsx
@@ -1,12 +1,12 @@
-import React from 'react'
+import React, { CSSProperties } from 'react'
 import styled from 'styled-components';
 
 const ChevronSVG = styled.svg`
   transition: 'transform 0.35s ease-in-out';
 `
 
-export const Chevron = ({style}) => (
+export const Chevron = ({ color = "#323232", style }: { color?: string, style?: CSSProperties }) => (
   <ChevronSVG width="9" height="14" viewBox="0 0 9 14" fill="none" xmlns="http://www.w3.org/2000/svg" style={style}>
-    <path d="M1 13L7.5 7L0.999999 1" stroke="#323232" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M1 13L7.5 7L0.999999 1" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
   </ChevronSVG>
 )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { FrigadeProvider } from './FrigadeProvider'
 export { FrigadeHeroChecklist } from './FrigadeHeroChecklist'
 export { FrigadeChecklist } from './FrigadeChecklist'
+export { FrigadeProgressBadge } from './FrigadeProgressBadge'
 export { useFlows } from './api/flows'
 export { useFlowResponses } from './api/flow-responses'
 export { useUser } from './api/users'


### PR DESCRIPTION
### Progress Badge
- Loads progress for given flow
<img width="197" alt="Screen Shot 2023-02-16 at 4 28 27 PM" src="https://user-images.githubusercontent.com/11068205/219511639-de49b3ec-7545-4e0a-8150-b55bdf0c5ab7.png">


Example usage:
```
<FrigadeProgressBadge
      flowId='flow_xyz'
      title="Get Started"
      style={{ backgroundColor: '#3661E1', borderColor: '#3661E1'}}
      primaryColor="#FFFFFF"
      secondaryColor="rgba(255, 255, 255, 0.4)"
      textStyle={{ color: '#FFFFFF'}}
      onClick={() => console.log('clicked item...')}
/>

```
Props
- `primaryColor`: text, chevron, and progress bar fill colors
- `secondaryColor`: progress bar bg
- `title` could probably be set from the Flow, but just being passed in as own prop at the moment
