### PR TITLE
feat: guide component

### DIFF
--- a/src/FrigadeGuide/FrigadeGuide.tsx
+++ b/src/FrigadeGuide/FrigadeGuide.tsx
@@ -1,0 +1,34 @@
+import React, { CSSProperties, FC } from 'react'
+import { useFlows } from '../api/flows'
+import { Guide } from '../Guides'
+
+export interface FrigadeGuideProps {
+  flowId: string
+  title: string
+  primaryColor?: string
+  style?: CSSProperties
+}
+
+export const FrigadeGuide: FC<FrigadeGuideProps> = ({ flowId, style, ...props }) => {
+
+  const {
+    getFlow,
+    targetingLogicShouldHideFlow,
+    getFlowSteps
+  } = useFlows()
+
+  const flow = getFlow(flowId)
+  if (!flow) {
+    return null
+  }
+
+  if (targetingLogicShouldHideFlow(flow)) {
+    return null
+  }
+
+  const steps = getFlowSteps(flowId)
+
+  return (
+    <Guide steps={steps} style={style} {...props} />
+  )
+}

--- a/src/FrigadeGuide/index.tsx
+++ b/src/FrigadeGuide/index.tsx
@@ -1,0 +1,1 @@
+export * from './FrigadeGuide'

--- a/src/Guides/Guide.tsx
+++ b/src/Guides/Guide.tsx
@@ -1,0 +1,81 @@
+import React, { CSSProperties, FC } from "react"
+import { StepData } from "../types"
+import { motion } from "framer-motion";
+
+import {
+  GuideContainer,
+  GuideItems,
+  GuideItem,
+  GuideTitle,
+
+  GuideIconWrapper,
+  GuideIcon,
+
+  GuideItemTitle,
+  GuideItemSubtitle,
+  GuideItemLink
+} from './styled'
+
+
+export interface GuideStepData extends StepData {
+  icon?: string
+}
+
+interface GuideProps {
+  steps: GuideStepData[]
+  title: string
+  style?: CSSProperties
+  primaryColor?: string
+}
+
+/**
+ * A guide is essentially a list of links that does not have a state
+ */
+const Guide: FC<GuideProps> = ({ steps, style, title, primaryColor }) => {
+
+  return (
+    <GuideContainer style={style}>
+      <GuideTitle>{title}</GuideTitle>
+      <GuideItems>
+        {
+        steps.map((stepData: GuideStepData, idx) => {
+          return (
+            <GuideItem
+              key={`guide-${stepData.id ?? idx}`}
+              as={motion.div}
+              whileHover={{
+                boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.05)',
+                transition: { duration: 0.25 },
+              }}
+            >
+              {
+                stepData.icon && (
+                  <GuideIconWrapper>
+                    <GuideIcon>
+                      {stepData.icon}
+                    </GuideIcon>
+                  </GuideIconWrapper>
+                )
+              }
+
+              <GuideItemTitle>
+                {stepData.title}
+              </GuideItemTitle>
+
+              <GuideItemSubtitle>
+                {stepData.subtitle}
+              </GuideItemSubtitle>
+
+              <GuideItemLink color={primaryColor} href={stepData.primaryButtonUri} target={stepData.primaryButtonUriTarget ?? '_self'}>
+                {stepData.primaryButtonTitle}
+              </GuideItemLink>
+            </GuideItem>
+          )
+        })
+      }
+      </GuideItems>
+    </GuideContainer>
+  )
+}
+
+export default Guide

--- a/src/Guides/__tests__/Guide.test.tsx
+++ b/src/Guides/__tests__/Guide.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import { Guide } from '..' 
+import { GuideStepData } from '../Guide'
+
+describe('Guide', () => {
+
+  const title = 'Test onboarding guide'
+  const steps: GuideStepData[] = [
+    {
+      id: 'workspaces',
+      title: 'Manage workspaces',
+      subtitle: 'Manage your different workspaces to achieve success with this product.',
+      primaryButtonTitle: 'Read guide',
+      icon: '📊',
+      complete: false,
+    },
+    {
+      id: 'labels',
+      title: 'Create and review labels',
+      icon: '🖍️',
+      subtitle: 'Create and review labels to achieve success with this product. Follow the guide to learn more.',
+      primaryButtonTitle: 'Read guide 2',
+      complete: false,
+    }
+  ]
+
+  test('renders content', () => {
+    render(<Guide steps={steps} title={title} />)
+    expect(screen.getByText(title)).toBeDefined()
+    steps.forEach((s: GuideStepData) => {
+      expect(screen.getByText(s.icon as string)).toBeDefined()
+      expect(screen.getByText(s.title as string)).toBeDefined()
+      expect(screen.getByText(s.subtitle as string)).toBeDefined()
+      expect(screen.getByText(s.primaryButtonTitle as string)).toBeDefined()
+    })
+  })
+})

--- a/src/Guides/index.tsx
+++ b/src/Guides/index.tsx
@@ -1,0 +1,1 @@
+export { default as Guide } from './Guide'

--- a/src/Guides/styled.ts
+++ b/src/Guides/styled.ts
@@ -1,0 +1,85 @@
+import styled from 'styled-components'
+
+export const GuideContainer = styled.div`
+  border: 1px solid #FAFAFA;
+  box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.05);
+  border-radius: 14px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+`
+
+export const GuideItems = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  overflow-y: scroll;
+`
+
+export const GuideTitle = styled.p`
+  color: #595959;
+  text-transform: uppercase;
+  font-weight: 400;
+  font-size: 10px;
+  line-height: 12px;
+`
+
+export const GuideItem = styled.div`
+  background: #FFFFFF;
+  border: 1px solid #FAFAFA;
+  border-radius: 14px;
+  padding: 20px;
+  margin: auto;
+  flex-direction: column;
+  align-content: left;
+
+  max-width: 25%;
+  min-width: 200px;
+  margin: 16px;
+`
+
+export const GuideIconWrapper = styled.div`
+  width: 40px;
+  height: 40px;
+
+  background: radial-gradient(50% 50% at 50% 50%, #FFFFFF 0%, #F7F7F7 100%);
+  border-radius: 7px;
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  align-items: center;
+`
+
+export const GuideIcon = styled.p`
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 24px;
+  width: 20px;
+  height: 20px;
+`
+
+export const GuideItemTitle = styled.p`
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 17px;
+  color: #434343;
+  margin-top: 12px;
+  margin-bottom: 8px;
+  color: #434343;
+`
+
+export const GuideItemSubtitle = styled.p`
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 14px;
+  color: #8C8C8C;
+`
+
+export const GuideItemLink = styled.a<{color: string}>`
+  color: ${(props) => props.color};
+  font-size: 12px;
+  line-height: 14px;
+  font-weight: 400;
+  text-decoration: underline;
+  cursor: pointer;
+`

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { FrigadeHeroChecklist } from './FrigadeHeroChecklist'
 export { FrigadeChecklist } from './FrigadeChecklist'
 export { FrigadeProgressBadge } from './FrigadeProgressBadge'
 export { FrigadeForm } from './FrigadeForm'
+export { FrigadeGuide } from './FrigadeGuide'
 export { FrigadeTour } from './FrigadeTour'
 
 export { useFlows } from './api/flows'


### PR DESCRIPTION
- Pulling the "guide" portion of the ChecklistWithGuide out into its own component
- Currently doesn't have state, and includes a new "icon" field 
    - Todo: should allow icon to be an image src/uri

| Example: https://app.frigade.com/flows/flow_Vk7HdLxGsseJKlaX |
| --- |
| <img width="1488" alt="Screen Shot 2023-02-25 at 12 15 57 PM" src="https://user-images.githubusercontent.com/11068205/221376091-cb2a0395-043c-4130-9ee5-24c7403d30c2.png"> |
