### PR TITLE
feat: checklist with guide appearance handling

### DIFF
--- a/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
+++ b/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
@@ -32,10 +32,11 @@ import {
 import { CenterVertical } from '../../components/styled'
 import { Modal } from '../../components/Modal'
 import Guide, { GuideStepData } from '../../Guides/Guide'
+import { getClassName } from '../../shared/appearance'
 
 
 // TODO: Create common Checlist props interface to extend
-interface ChecklistWithGuideProps extends ModalChecklistProps {
+export interface ChecklistWithGuideProps extends ModalChecklistProps {
   
   // Map from string to function with StepData returning React.ReactNode
   // TODO: Move to common Checlist props interface
@@ -63,6 +64,9 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
   selectedStep,
   setSelectedStep,
   customStepTypes,
+
+  appearance,
+
   guideData,
   guideTitle,
 }) => {
@@ -72,12 +76,13 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
     if(!stepData) return <></>
 
     return (
-      <StepContainer>
-        <StepTitle>{stepData.title}</StepTitle>
-        <StepSubtitle>{stepData.subtitle}</StepSubtitle>
+      <StepContainer className={getClassName('checklistStepContainer', appearance)} data-testid='checklistStepContainer'>
+        <StepTitle className={getClassName('checklistStepTitle', appearance)}>{stepData.title}</StepTitle>
+        <StepSubtitle className={getClassName('checklistStepSubtitle', appearance)}>{stepData.subtitle}</StepSubtitle>
         <MultipleButtonContainer>
           {stepData.secondaryButtonTitle && (
             <Button
+              className={getClassName('checklistStepSecondaryButton', appearance)}
               title={stepData.secondaryButtonTitle}
               onClick={handleSecondaryCTAClick}
               style={{ borderColor: '#D9D9D9', width: 'auto', backgroundColor: '#FFFFFF', borderRadius: '30px' }}
@@ -85,6 +90,7 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
             />
           )}
           <Button
+            className={getClassName('checklistStepPrimaryButton', appearance)}
             title={stepData.primaryButtonTitle}
             onClick={handleCTAClick}
             style={{
@@ -155,10 +161,11 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
       visible={visible}
       style={ContainerStyle}
       closeTint={'#8C8C8C'}
+      appearance={appearance}
     >
       <HeaderContent>
-        <ChecklistTitle>{title}</ChecklistTitle>
-        <ChecklistSubtitle>{subtitle}</ChecklistSubtitle>
+        <ChecklistTitle className={getClassName('checklistTitle', appearance)}>{title}</ChecklistTitle>
+        <ChecklistSubtitle className={getClassName('checklistSubtitle', appearance)}>{subtitle}</ChecklistSubtitle>
       </HeaderContent>
 
       <ScrollContainer>
@@ -172,24 +179,28 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
             </ProgressBarContainer>
           </StepsHeader>
           <StepsBody>
-            <StepListContainer>
+            <StepListContainer className={getClassName('checklistStepListContainer', appearance)}>
               {
                   steps.map((stepData: StepData, idx: number) => {
                     const isSelected = selectedStepValue === idx;
                     return (
                       <StepListItem selected={isSelected}
+                        className={getClassName(`checklistStepListItem${isSelected && 'Selected'}`, appearance)}
                         key={`checklist-guide-step-${stepData.id ?? idx}`}
                         onClick={() => {
                           setSelectedStepValue(idx)
                         }}>
                         {isSelected && (
                           <StepItemSelectedIndicator
+                            className={getClassName('checklistStepItemSelectedIndicator', appearance)}
                             as={motion.div}
                             layoutId="checklist-step-selected"
                             style={{ backgroundColor: primaryColor, borderRadius: 0, height: '100%', top: '0%', width: '2px'}}
                           ></StepItemSelectedIndicator>
                         )}
-                        <StepListStepName selected={isSelected}>
+                        <StepListStepName
+                          selected={isSelected} 
+                          className={getClassName(`checklistStepListStepName${isSelected && 'Selected'}`, appearance)}>
                           {stepData.stepName}
                         </StepListStepName>
                         <StepListItemRight>

--- a/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
+++ b/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
@@ -227,7 +227,9 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
                 style={{
                   border: 'none',
                   boxShadow: 'none'
-              }}/>
+                }}
+                appearance={appearance}
+              />
             )
           }
       </ScrollContainer>

--- a/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
+++ b/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
@@ -160,7 +160,7 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
       onClose={onClose}
       visible={visible}
       style={ContainerStyle}
-      closeTint={'#8C8C8C'}
+      closeTint={appearance?.styleOverrides?.iconColor ?? '#8C8C8C'}
       appearance={appearance}
     >
       <HeaderContent>
@@ -169,7 +169,7 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
       </HeaderContent>
 
       <ScrollContainer>
-        <StepsContainer>
+        <StepsContainer className={getClassName('stepsContainer', appearance)}>
           <StepsHeader>
             <div style={{flex: 3}}>
               <StepsTitle>{stepsTitle}</StepsTitle>
@@ -206,7 +206,7 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
                         <StepListItemRight>
                           <CheckBox value={stepData.complete} type='round' primaryColor={primaryColor} secondaryColor={secondaryColor}/>
                           <CenterVertical>
-                            <Chevron style={{ marginLeft: '10px' }} />
+                            <Chevron style={{ marginLeft: '10px' }} color={appearance?.styleOverrides?.iconColor}/>
                           </CenterVertical>
                         </StepListItemRight>
                       </StepListItem>

--- a/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
+++ b/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
@@ -185,7 +185,7 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
                     const isSelected = selectedStepValue === idx;
                     return (
                       <StepListItem selected={isSelected}
-                        className={getClassName(`checklistStepListItem${isSelected && 'Selected'}`, appearance)}
+                        className={getClassName(`checklistStepListItem${isSelected ? 'Selected' : ''}`, appearance)}
                         key={`checklist-guide-step-${stepData.id ?? idx}`}
                         onClick={() => {
                           setSelectedStepValue(idx)
@@ -200,7 +200,7 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
                         )}
                         <StepListStepName
                           selected={isSelected} 
-                          className={getClassName(`checklistStepListStepName${isSelected && 'Selected'}`, appearance)}>
+                          className={getClassName(`checklistStepListStepName${isSelected ? 'Selected' : ''}`, appearance)}>
                           {stepData.stepName}
                         </StepListStepName>
                         <StepListItemRight>

--- a/src/Checklists/ChecklistWithGuide/__tests__/ChecklistWithGuide.test.tsx
+++ b/src/Checklists/ChecklistWithGuide/__tests__/ChecklistWithGuide.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import  { ChecklistWithGuide } from ".."
+import  { ChecklistWithGuide, ChecklistWithGuideProps } from ".."
 import { render, screen, fireEvent } from '@testing-library/react'
 import { StepData } from "../../../types"
 
@@ -23,7 +23,7 @@ describe('ChecklistWithGuide', () => {
     handleSecondaryButtonClick: jest.fn(),
   }
 
-  const testProps = {
+  const testProps: ChecklistWithGuideProps = {
     title: 'Test Checklist',
     subtitle: 'Test Checklist subtitle',
     visible: true,
@@ -47,5 +47,15 @@ describe('ChecklistWithGuide', () => {
     render(<ChecklistWithGuide {...testProps} />)
     fireEvent.click(screen.getByText(stepData.secondaryButtonTitle as string))
     expect(stepData.handleSecondaryButtonClick).toHaveBeenCalledTimes(1)
+  })
+
+  test('applies custom style overrides', () => {
+    testProps.appearance = {
+      styleOverrides: {
+        checklistStepContainer: 'bg-black text-white',
+      }
+    }
+    render(<ChecklistWithGuide {...testProps} />)
+    expect(screen.getByTestId('checklistStepContainer').className).toContain('bg-black text-white')
   })
 })

--- a/src/Checklists/ChecklistWithGuide/index.tsx
+++ b/src/Checklists/ChecklistWithGuide/index.tsx
@@ -1,1 +1,2 @@
 export { default as ChecklistWithGuide } from './ChecklistWithGuide';
+export type { ChecklistWithGuideProps } from './ChecklistWithGuide';

--- a/src/Checklists/ChecklistWithGuide/styled.ts
+++ b/src/Checklists/ChecklistWithGuide/styled.ts
@@ -49,6 +49,7 @@ export const StepsContainer = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 240px;
+  overflow: hidden;
 `
 
 export const StepsHeader = styled.div`
@@ -115,7 +116,7 @@ export const MultipleButtonContainer = styled.div`
 export const StepListItem = styled.div<{ selected: boolean }>`
   :not(${(props) => getCustomClasOverrides(props)}) {
     // Anything inside this block will be ignored if the user provides a custom class
-    /* background-color: ${(props) => (props.selected ? '#FAFAFA' : '#FFFFFF')}; */
+    background-color: ${(props) => (props.selected ? '#FAFAFA' : '#FFFFFF')};
   }
   padding: 20px;
   display: flex;

--- a/src/Checklists/ChecklistWithGuide/styled.ts
+++ b/src/Checklists/ChecklistWithGuide/styled.ts
@@ -1,10 +1,10 @@
 import { CSSProperties } from 'react'
 import styled from 'styled-components'
+import { getCustomClasOverrides } from '../../shared/appearance'
 
 // Styles for top level container and text
 
 export const ContainerStyle: CSSProperties = {
-  background: '#ffffff',
   boxShadow: '0px 6px 25px rgba(0, 0, 0, 0.06)',
   borderRadius: '6px',
   padding: '32px',
@@ -113,8 +113,11 @@ export const MultipleButtonContainer = styled.div`
 `
 
 export const StepListItem = styled.div<{ selected: boolean }>`
+  :not(${(props) => getCustomClasOverrides(props)}) {
+    // Anything inside this block will be ignored if the user provides a custom class
+    /* background-color: ${(props) => (props.selected ? '#FAFAFA' : '#FFFFFF')}; */
+  }
   padding: 20px;
-  background-color: ${(props) => (props.selected ? '#FAFAFA' : '#FFFFFF')};
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -122,10 +125,13 @@ export const StepListItem = styled.div<{ selected: boolean }>`
 `
 
 export const StepListStepName = styled.p<{ selected: boolean }>`
+:not(${(props) => getCustomClasOverrides(props)}) {
+    // Anything inside this block will be ignored if the user provides a custom class
+    color: ${(props) => (props.selected ? '#434343' : '#BFBFBF')};
+  }
   font-weight: ${(props) => (props.selected ? 500 : 400)};
   font-size: 14px;
   line-height: 22px;
-  color: ${(props) => (props.selected ? '#434343' : '#BFBFBF')};
   margin: 0;
 `
 

--- a/src/Checklists/ChecklistWithGuide/styled.ts
+++ b/src/Checklists/ChecklistWithGuide/styled.ts
@@ -43,7 +43,9 @@ export const ChecklistSubtitle = styled.p`
 `
 
 export const StepsContainer = styled.div`
-  border: 1px solid #fafafa;
+  :not(${(props) => getCustomClasOverrides(props)}) {
+    border: 1px solid #fafafa;
+  }
   box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.05);
   border-radius: 14px;
   display: flex;

--- a/src/Checklists/ModalChecklist/ModalChecklist.tsx
+++ b/src/Checklists/ModalChecklist/ModalChecklist.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from 'react'
-import { StepData } from '../../types'
+import { Appearance, StepData } from '../../types'
 import { Modal } from '../../components/Modal'
 import { ProgressBar } from '../Checklist/Progress'
 import { CollapsibleStep } from './CollapsibleStep'
@@ -19,6 +19,8 @@ export interface ModalChecklistProps {
   primaryColor?: string
   selectedStep?: number
   setSelectedStep?: (index: number) => void
+
+  appearance?: Appearance
 }
 
 const ModalChecklist: FC<ModalChecklistProps> = ({

--- a/src/FrigadeChecklist/index.tsx
+++ b/src/FrigadeChecklist/index.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, useEffect, useState } from 'react'
 
 import { useFlows } from '../api/flows'
 import { HeroChecklist, HeroChecklistProps } from '../Checklists/HeroChecklist'
-import { StepData } from '../types'
+import { Appearance, StepData } from '../types'
 import { ModalChecklist } from '../Checklists/ModalChecklist'
 import { COMPLETED_STEP } from '../api/common'
 import { primaryCTAClickSideEffects, secondaryCTAClickSideEffects } from '../shared/cta-util'
@@ -48,6 +48,8 @@ export interface FrigadeChecklistProps extends HeroChecklistProps {
 
   onButtonClick?: (step: StepData, index: number, cta: 'primary' | 'secondary') => boolean
 
+  appearance?: Appearance
+
   /**
    *  Optionl Props specifically for ChecklistWithGuide
    *
@@ -72,6 +74,7 @@ export const FrigadeChecklist: React.FC<FrigadeChecklistProps> = ({
   customVariables,
   onStepCompletion,
   onButtonClick,
+  appearance,
   ...guideProps
 }) => {
   const {
@@ -188,6 +191,7 @@ export const FrigadeChecklist: React.FC<FrigadeChecklistProps> = ({
     title,
     subtitle,
     primaryColor,
+    appearance,
   }
 
   if (type === 'modal') {

--- a/src/Guides/Guide.tsx
+++ b/src/Guides/Guide.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, FC } from "react"
-import { StepData } from "../types"
+import { Appearance, StepData } from "../types"
 import { motion } from "framer-motion";
 
 import {
@@ -15,6 +15,7 @@ import {
   GuideItemSubtitle,
   GuideItemLink
 } from './styled'
+import { getClassName } from "../shared/appearance";
 
 
 export interface GuideStepData extends StepData {
@@ -26,16 +27,17 @@ interface GuideProps {
   title: string
   style?: CSSProperties
   primaryColor?: string
+  appearance: Appearance
 }
 
 /**
  * A guide is essentially a list of links that does not have a state
  */
-const Guide: FC<GuideProps> = ({ steps, style, title, primaryColor }) => {
+const Guide: FC<GuideProps> = ({ steps, style, title, primaryColor, appearance }) => {
 
   return (
-    <GuideContainer style={style}>
-      <GuideTitle>{title}</GuideTitle>
+    <GuideContainer style={style} className={getClassName('guideContainer', appearance)}>
+      <GuideTitle className={getClassName('guideTitle', appearance)}>{title}</GuideTitle>
       <GuideItems>
         {
         steps.map((stepData: GuideStepData, idx) => {
@@ -47,6 +49,7 @@ const Guide: FC<GuideProps> = ({ steps, style, title, primaryColor }) => {
                 boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.05)',
                 transition: { duration: 0.25 },
               }}
+              className={getClassName('guideItem', appearance)}
             >
               {
                 stepData.icon && (
@@ -58,15 +61,19 @@ const Guide: FC<GuideProps> = ({ steps, style, title, primaryColor }) => {
                 )
               }
 
-              <GuideItemTitle>
+              <GuideItemTitle className={getClassName('guideItemTitle', appearance)}>
                 {stepData.title}
               </GuideItemTitle>
 
-              <GuideItemSubtitle>
+              <GuideItemSubtitle className={getClassName('guideItemSubtitle', appearance)}>
                 {stepData.subtitle}
               </GuideItemSubtitle>
 
-              <GuideItemLink color={primaryColor} href={stepData.primaryButtonUri} target={stepData.primaryButtonUriTarget ?? '_self'}>
+              <GuideItemLink className={getClassName('guideIteLink', appearance)}
+                color={primaryColor}
+                href={stepData.primaryButtonUri}
+                target={stepData.primaryButtonUriTarget ?? '_self'}
+              >
                 {stepData.primaryButtonTitle}
               </GuideItemLink>
             </GuideItem>

--- a/src/Guides/styled.ts
+++ b/src/Guides/styled.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { getCustomClasOverrides } from '../shared/appearance'
 
 export const GuideContainer = styled.div`
   border: 1px solid #fafafa;
@@ -17,17 +18,23 @@ export const GuideItems = styled.div`
 `
 
 export const GuideTitle = styled.div`
-  color: #595959;
+  :not(${(props) => getCustomClasOverrides(props)}) {
+    color: #595959;
+  }
   text-transform: uppercase;
   font-weight: 400;
   font-size: 10px;
   line-height: 12px;
   letter-spacing: 0.09em;
+  margin-bottom: 12px;
 `
 
 export const GuideItem = styled.div`
-  background: #ffffff;
-  border: 1px solid #fafafa;
+  :not(${(props) => getCustomClasOverrides(props)}) {
+    // Anything inside this block will be ignored if the user provides a custom class
+    background: #ffffff;
+    border: 1px solid #fafafa;
+  }
   border-radius: 14px;
   padding: 20px;
   flex-direction: column;
@@ -38,10 +45,12 @@ export const GuideItem = styled.div`
 `
 
 export const GuideIconWrapper = styled.div`
+  :not(${(props) => getCustomClasOverrides(props)}) {
+    background: radial-gradient(50% 50% at 50% 50%, #ffffff 0%, #f7f7f7 100%);
+  }
   width: 40px;
   height: 40px;
 
-  background: radial-gradient(50% 50% at 50% 50%, #ffffff 0%, #f7f7f7 100%);
   border-radius: 7px;
   display: flex;
   justify-content: center;
@@ -58,20 +67,23 @@ export const GuideIcon = styled.div`
 `
 
 export const GuideItemTitle = styled.div`
+  :not(${(props) => getCustomClasOverrides(props)}) {
+    color: #434343;
+  }
   font-weight: 600;
   font-size: 14px;
   line-height: 17px;
-  color: #434343;
   margin-top: 12px;
   margin-bottom: 8px;
-  color: #434343;
 `
 
 export const GuideItemSubtitle = styled.div`
+  :not(${(props) => getCustomClasOverrides(props)}) {
+    color: #8c8c8c;
+  }
   font-weight: 400;
   font-size: 12px;
   line-height: 14px;
-  color: #8c8c8c;
 `
 
 export const GuideItemLink = styled.a<{ color: string }>`


### PR DESCRIPTION
- [x] Checklist classnames
- [x] Guide classnames - pass appearance down through

<img width="1052" alt="Screen Shot 2023-03-03 at 8 21 59 AM" src="https://user-images.githubusercontent.com/11068205/222758776-a9be9b00-0780-461d-ac90-062ece64b9a2.png">
