### PR TITLE
feat: step flow progress for flow completion criteria

### DIFF
--- a/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
+++ b/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
@@ -209,6 +209,7 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
                             type='round'
                             primaryColor={primaryColor}
                             secondaryColor={secondaryColor}
+                            progress={stepData.progress}
                           />
                           <CenterVertical>
                             <Chevron style={{ marginLeft: '10px' }} color={appearance?.styleOverrides?.iconColor}/>

--- a/src/FrigadeChecklist/index.tsx
+++ b/src/FrigadeChecklist/index.tsx
@@ -87,6 +87,7 @@ export const FrigadeChecklist: React.FC<FrigadeChecklistProps> = ({
     targetingLogicShouldHideFlow,
     setCustomVariable,
     customVariables: existingCustomVariables,
+    getStepOptionalProgress
   } = useFlows()
   const { getOpenFlowState, setOpenFlowState } = useFlowOpens()
   const [selectedStep, setSelectedStep] = useState(initialSelectedStep || 0)
@@ -183,6 +184,7 @@ export const FrigadeChecklist: React.FC<FrigadeChecklistProps> = ({
           }
           primaryCTAClickSideEffects(step)
         },
+        progress: getStepOptionalProgress(step)
       }
     })
   }

--- a/src/api/completionUtil.ts
+++ b/src/api/completionUtil.ts
@@ -1,0 +1,23 @@
+const regex = /user.flow\(([^\)]+)\).state == 'COMPLETED_FLOW'/gm;
+
+
+export const getSubFlowFromCompletionCriteria = (completionCriteria: string) => {
+
+  const flowMatch = regex.exec(completionCriteria)
+  if (flowMatch === null) return null;
+
+  /**
+   *  Use the grouped regex match to
+   *  - match on full completion criteria for a 'Flow' completion
+   *  - get the flowId slug from within the completion criteria
+   */
+  let flow = null;
+  flowMatch.forEach((match, groupIndex) => {
+    let trimmed = match.replaceAll("'", "")
+    if (trimmed.startsWith('flow_')) {
+      console.log('found slug: ', trimmed)
+      flow = trimmed
+    }
+  })
+  return flow
+}

--- a/src/api/flows.ts
+++ b/src/api/flows.ts
@@ -12,6 +12,8 @@ import { FrigadeContext } from '../FrigadeProvider'
 import { useFlowResponses } from './flow-responses'
 import useSWR from 'swr'
 import { useUserFlowStates } from './user-flow-states'
+import { StepData } from '../types'
+import { getSubFlowFromCompletionCriteria } from './completionUtil'
 
 export interface Flow {
   id: number
@@ -127,6 +129,18 @@ export function useFlows() {
     return (maybeFlowResponse ? maybeFlowResponse.actionType : 'NOT_STARTED_STEP') as StepActionType
   }
 
+  function getStepOptionalProgress(step: StepData) {
+    if(!step.completionCriteria) return undefined;
+    
+    const stepSubFlowSlug = getSubFlowFromCompletionCriteria(step.completionCriteria)
+    if (stepSubFlowSlug === null) return undefined;
+
+    const completed = getNumberOfStepsCompleted(stepSubFlowSlug)
+    const total = getNumberOfSteps(stepSubFlowSlug)
+
+    return total === 0 ? undefined : (completed / total)
+  }
+
   function getFlowStatus(flowSlug: string) {
     if (getNumberOfStepsCompleted(flowSlug) === getNumberOfSteps(flowSlug)) {
       return COMPLETED_FLOW
@@ -197,5 +211,6 @@ export function useFlows() {
     targetingLogicShouldHideFlow,
     setCustomVariable,
     customVariables,
+    getStepOptionalProgress,
   }
 }

--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -100,7 +100,7 @@ export const CheckBox: FC<CheckBoxProps> = (
     }
   }
 
-  if (type === 'round' && progress !== undefined) {
+  if (type === 'round' && progress !== undefined && progress !== 1) {
     return (
       <ProgressRing fillColor={primaryColor} percentage={progress} size={18}/>
     )

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -26,6 +26,7 @@ export interface StepData {
   imageStyle?: CSSProperties
   props?: any
   completionCriteria?: string
+  progress?: number
 }
 
 export interface DefaultFrigadeFlowProps {


### PR DESCRIPTION
- If step contains a `user.flow('flow-id').state == 'COMPLETED_FLOW'` completion criteria, fetch the current progress of the flow and pass down as `progress` prop to the step + checkbox


https://user-images.githubusercontent.com/11068205/222913365-8cf129f6-632a-4ac0-bfa1-654f947f67b0.mov

