### PR TITLE
feat: use deep copy for default appearance

### DIFF
--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -74,14 +74,17 @@ export const DefaultAppearance: Appearance = {
 }
 
 export function mergeAppearanceWithDefault(appearance?: Appearance): Appearance {
+  const _appearance = JSON.parse(JSON.stringify(DefaultAppearance));
+
   if (!appearance) {
-    return DefaultAppearance
+    return _appearance
   }
+
   return {
     styleOverrides: Object.assign(
-      DefaultAppearance.styleOverrides ?? {},
+      _appearance.styleOverrides ?? {},
       appearance.styleOverrides ?? {}
     ),
-    theme: Object.assign(DefaultAppearance.theme, appearance.theme ?? {}),
+    theme: Object.assign(_appearance.theme, appearance.theme ?? {}),
   }
 }


### PR DESCRIPTION
- The `mergeAppearanceWithDefault` function was returning objects shallow copied form the `DefaultAppearance`. This means that if we set `theme.primaryColor` for one component, it will also be set for other components in use
    - e.g. setting the `theme.colorPrimary: '#ffffff'` for the `FrigadeProgressBadge` was causing the modal checklist to also try and render itself with a `theme.colorPrimary: '#ffffff'` instead of whatever color was passed to it
- used the object -> string -> object method suggested here: https://developer.mozilla.org/en-US/docs/Glossary/Deep_copy