### PR TITLE
fix: add appearance handling for modal checklist

### DIFF
--- a/src/Checklists/ModalChecklist/CollapsibleStep/index.tsx
+++ b/src/Checklists/ModalChecklist/CollapsibleStep/index.tsx
@@ -39,19 +39,20 @@ export const CollapsibleStep: FC<CollapsibleStepProps> = ({
     <StepContainer
       onClick={() => (collapsed ? onClick() : null)}
       data-testid={`step-${stepData.id}`}
+      appearance={appearance}
     >
       <StepHeader>
         <HeaderLeft>
           <CheckBoxRow
             value={stepData.complete}
             style={{ width: 'auto', borderTop: 0 }}
-            primaryColor={primaryColor}
+            primaryColor={appearance?.theme?.colorPrimary}
           />
-          <StepTitle>{stepData.title}</StepTitle>
+          <StepTitle appearance={appearance}>{stepData.title}</StepTitle>
         </HeaderLeft>
 
         <CollapseChevronContainer onClick={() => onClick()}>
-          <Chevron style={{ ...iconStyle, transition: 'transform 0.1s ease-in-out' }} />
+          <Chevron style={{ ...iconStyle, transition: 'transform 0.1s ease-in-out' }} color={appearance?.theme?.colorTextSecondary}/>
         </CollapseChevronContainer>
       </StepHeader>
 
@@ -64,7 +65,7 @@ export const CollapsibleStep: FC<CollapsibleStepProps> = ({
             key={stepData.id}
             style={{ overflow: 'hidden' }}
           >
-            <StepSubtitle>{stepData.subtitle}</StepSubtitle>
+            <StepSubtitle appearance={appearance}>{stepData.subtitle}</StepSubtitle>
             <MultipleButtonContainer>
               <Button
                 title={stepData.primaryButtonTitle ?? 'Continue'}

--- a/src/Checklists/ModalChecklist/CollapsibleStep/styled.ts
+++ b/src/Checklists/ModalChecklist/CollapsibleStep/styled.ts
@@ -1,8 +1,9 @@
 import styled from 'styled-components'
 
-export const StepContainer = styled.div`
-  background: #ffffff;
-  border: 1px solid #e6e6e6;
+export const StepContainer = styled.div<{ appearance }>`
+  background-color: ${(props) => props.appearance?.theme?.colorBackground};
+  border: 1px solid;
+  border-color: ${(props) => props.appearance?.theme?.colorBorder};
   border-radius: 6px;
   padding: 2px 20px 2px 20px;
   display: flex;
@@ -20,7 +21,8 @@ export const StepHeader = styled.div`
   align-items: center;
 `
 
-export const StepTitle = styled.p`
+export const StepTitle = styled.p<{ appearance }>`
+  color: ${(props) => props.appearance?.theme?.colorText};
   font-style: normal;
   font-weight: 500;
   font-size: 16px;
@@ -34,11 +36,11 @@ export const CollapseChevronContainer = styled.div`
 
 export const ExpandedContentContainer = styled.div``
 
-export const StepSubtitle = styled.p`
+export const StepSubtitle = styled.p<{ appearance }>`
+  color: ${(props) => props.appearance?.theme?.colorText};
   font-weight: 400;
   font-size: 14px;
   line-height: 22px;
-  color: #4d4d4d;
 `
 
 export const HeaderLeft = styled.div`

--- a/src/Checklists/ModalChecklist/ModalChecklist.tsx
+++ b/src/Checklists/ModalChecklist/ModalChecklist.tsx
@@ -77,11 +77,13 @@ const ModalChecklist: FC<ModalChecklistProps> = ({
       <Modal
         onClose={onClose}
         visible={visible}
+        appearance={appearance}
+        style={{ maxWidth: '600px' }}
         headerContent={
           <>
             <HeaderContent>
-              <ModalChecklistTitle>{title}</ModalChecklistTitle>
-              <ModalChecklistSubtitle>{subtitle}</ModalChecklistSubtitle>
+              <ModalChecklistTitle appearance={appearance}>{title}</ModalChecklistTitle>
+              <ModalChecklistSubtitle appearance={appearance}>{subtitle}</ModalChecklistSubtitle>
             </HeaderContent>
             <ProgressBar
               display="percent"
@@ -89,10 +91,10 @@ const ModalChecklist: FC<ModalChecklistProps> = ({
               total={steps.length}
               fillColor={primaryColor}
               style={{ margin: '14px 0px 8px 0px' }}
+              appearance={appearance}
             />
           </>
         }
-        style={{ maxWidth: '600px' }}
       >
         {steps.map((step: StepData, idx: number) => {
           const isCollapsed = collapsedSteps[idx]

--- a/src/Checklists/ModalChecklist/styled.ts
+++ b/src/Checklists/ModalChecklist/styled.ts
@@ -21,14 +21,16 @@ export const HeaderContent = styled.div`
   flex-direction: column;
 `
 
-export const ModalChecklistTitle = styled.p`
+export const ModalChecklistTitle = styled.p<{ appearance }>`
+  color: ${(props) => props.appearance?.theme?.colorText};
   font-style: normal;
   font-weight: 700;
   font-size: 20px;
   line-height: 24px;
   margin-bottom: 8px;
 `
-export const ModalChecklistSubtitle = styled.p`
+export const ModalChecklistSubtitle = styled.p<{ appearance }>`
+  color: ${(props) => props.appearance?.theme?.colorTextSecondary};
   font-weight: 400;
   color: #4d4d4d;
   font-size: 14px;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -6,10 +6,10 @@ import { CloseIcon } from '../CloseIcon'
 import { getClassName, getCustomClasOverrides } from '../../shared/appearance'
 import { Appearance } from '../../types'
 
-const ModalContainer = styled.div`
+const ModalContainer = styled.div<{ appearance }>`
   :not(${(props) => getCustomClasOverrides(props)}) {
     // Anything inside this block will be ignored if the user provides a custom class
-    background: #ffffff;
+    background-color: ${(props) => props.appearance?.theme?.colorBackground};
     /* Mobile */
     @media (max-width: 500px) {
       width: 90%;
@@ -47,14 +47,14 @@ const ModalHeader = styled.div`
   flex: 1;
 `
 
-const ModalClose = styled.div`
+const ModalClose = styled.div<{ appearance }>`
   position: absolute;
   top: 16px;
   right: 16px;
   cursor: pointer;
   :not(${(props) => getCustomClasOverrides(props)}) {
     // Anything inside this block will be ignored if the user provides a custom class
-    color: #000000;
+    color: ${(props) => props.appearance?.theme?.colorText};
   }
 `
 
@@ -109,8 +109,8 @@ export const Modal: FC<ModalProps> = ({
   return (
     <>
       <ModalBackground appearance={appearance} onClose={onClose} />
-      <ModalContainer className={getClassName('modalContainer', appearance)} style={style}>
-        <ModalClose className={getClassName('modalClose', appearance)} onClick={() => onClose()}>
+      <ModalContainer appearance={appearance} className={getClassName('modalContainer', appearance)} style={style}>
+        <ModalClose className={getClassName('modalClose', appearance)} onClick={() => onClose()} appearance={appearance}>
           <CloseIcon />
         </ModalClose>
         {headerContent && <ModalHeader>{headerContent}</ModalHeader>}

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -80,6 +80,7 @@ export interface BaseTheme {
   colorText?: string
   colorTextOnPrimaryBackground?: string
   colorTextSecondary?: string
+  colorBorder?: string
   fontSize?: string | number
   fontSmoothing?: string
   fontWeight?: string | number
@@ -94,6 +95,7 @@ export const DefaultAppearance: Appearance = {
     colorBackgroundSecondary: '#ffffff66',
     colorTextOnPrimaryBackground: '#ffffff',
     colorTextSecondary: '#000000',
+    colorBorder: '#E6E6E6',
     borderRadius: 8,
   },
 }


### PR DESCRIPTION
- Pass appearance down through modal checklist
- Adds `colorBorder` field to `BaseTheme` type

| Default | Dark |
| --- | --- |
| <img width="718" alt="Screen Shot 2023-03-08 at 10 31 26 AM" src="https://user-images.githubusercontent.com/11068205/223787185-85123416-c4ed-4725-b085-a987b1ff447b.png"> | <img width="739" alt="Screen Shot 2023-03-08 at 10 31 16 AM" src="https://user-images.githubusercontent.com/11068205/223787190-e182105e-252a-4d7a-b042-c56cd4528c5c.png"> |
