### PR TITLE
Fixed a whole mess of minor TSC issues

### DIFF
--- a/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
+++ b/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
@@ -165,7 +165,6 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
     <Modal
       onClose={onClose}
       visible={visible}
-      closeTint={appearance?.styleOverrides?.iconColor ?? '#8C8C8C'}
       appearance={appearance}
     >
       <ChecklistContainer>

--- a/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
+++ b/src/Checklists/ChecklistWithGuide/ChecklistWithGuide.tsx
@@ -290,6 +290,8 @@ const ChecklistWithGuide: FC<ChecklistWithGuideProps> = ({
                 if (onGuideButtonClick) {
                   onGuideButtonClick(step)
                 }
+
+                return true
               }}
             />
           )}

--- a/src/Checklists/HeroChecklist/HeroChecklist.tsx
+++ b/src/Checklists/HeroChecklist/HeroChecklist.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../components/checklist-step-content/CodeSnippetContent'
 import { useTheme } from '../../hooks/useTheme'
 
-export interface HeroChecklistProps extends DefaultFrigadeFlowProps {
+export interface HeroChecklistProps extends Omit<DefaultFrigadeFlowProps, 'flowId'> {
   title?: string
   subtitle?: string
   /**

--- a/src/Checklists/HeroChecklist/HeroChecklist.tsx
+++ b/src/Checklists/HeroChecklist/HeroChecklist.tsx
@@ -170,7 +170,7 @@ const HeroChecklist: FC<HeroChecklistProps> = ({
       </ChecklistHeader>
       <Divider />
       <HeroChecklistStepContentContainer>
-        <StepContent appearance={appearance} />
+        <StepContent />
       </HeroChecklistStepContentContainer>
     </HeroChecklistContainer>
   )

--- a/src/Checklists/HeroChecklist/StepChecklistItem.tsx
+++ b/src/Checklists/HeroChecklist/StepChecklistItem.tsx
@@ -38,7 +38,7 @@ export const StepChecklistItem: FC<StepItemProps> = ({
           className={getClassName('checklistStepItemSelectedIndicator', appearance)}
           as={motion.div}
           layoutId="checklis-step-selected"
-          style={{ backgroundColor: appearance?.theme?.primaryColor ?? primaryColor }}
+          style={{ backgroundColor: appearance?.theme?.colorPrimary ?? primaryColor }}
         ></StepItemSelectedIndicator>
       )}
       <ChecklistStepItem key={`hero-checklist-step-${index}`} role="listitem">
@@ -47,7 +47,7 @@ export const StepChecklistItem: FC<StepItemProps> = ({
           labelPosition="left"
           label={data.stepName}
           style={style}
-          primaryColor={appearance?.theme?.primaryColor ?? primaryColor}
+          primaryColor={appearance?.theme?.colorPrimary ?? primaryColor}
           appearance={appearance}
         />
       </ChecklistStepItem>

--- a/src/Checklists/ModalChecklist/ModalChecklist.tsx
+++ b/src/Checklists/ModalChecklist/ModalChecklist.tsx
@@ -138,7 +138,6 @@ const ModalChecklist: FC<ModalChecklistProps> = ({
                     step.handleSecondaryButtonClick()
                   }
                 }}
-                primaryColor={primaryColor}
               />
             )
           })}

--- a/src/FrigadeBanner/index.tsx
+++ b/src/FrigadeBanner/index.tsx
@@ -30,6 +30,9 @@ export type FrigadeBannerType = 'full-width' | 'square'
 
 export interface FrigadeBannerProps extends DefaultFrigadeFlowProps {
   type?: FrigadeBannerType
+  title?: string
+  subtitle?: string
+  onDismiss?: () => void
 }
 
 export const FrigadeBanner: React.FC<FrigadeBannerProps> = ({

--- a/src/FrigadeChecklist/index.tsx
+++ b/src/FrigadeChecklist/index.tsx
@@ -289,7 +289,6 @@ export const FrigadeChecklist: React.FC<FrigadeChecklistProps> = ({
           onClose={() => {
             handleClose()
           }}
-          secondaryColor={appearance.theme.colorSecondary}
           selectedStep={selectedStep}
           setSelectedStep={setSelectedStep}
           guideData={guideFlowSteps}
@@ -314,7 +313,7 @@ export const FrigadeChecklist: React.FC<FrigadeChecklistProps> = ({
         selectedStep={selectedStep}
         setSelectedStep={setSelectedStep}
         className={className}
-        apperaance={appearance}
+        appearance={appearance}
         {...commonProps}
       />
     </>

--- a/src/FrigadeForm/FormContent.tsx
+++ b/src/FrigadeForm/FormContent.tsx
@@ -200,7 +200,6 @@ export const FormContent: FC<FormContentProps> = ({
                       }}
                       onBack={() => {}}
                       steps={steps}
-                      currentStep={selectedStep}
                     />
                   </FormContainerWrapper>
                 </motion.div>

--- a/src/FrigadeForm/FormContent.tsx
+++ b/src/FrigadeForm/FormContent.tsx
@@ -26,6 +26,7 @@ interface FormContentProps extends DefaultFrigadeFlowProps {
   customStepTypes?: { [key: string]: (params: CustomFormTypeProps) => React.ReactNode }
   type: FrigadeFormType
   setShowModal: (showModal: boolean) => void
+  setVisible?: (visible: boolean) => void
 }
 export const FormContent: FC<FormContentProps> = ({
   appearance,

--- a/src/FrigadeForm/FormFooter.tsx
+++ b/src/FrigadeForm/FormFooter.tsx
@@ -28,7 +28,7 @@ export const FormFooter: FC<FormFooterProps> = ({
   steps,
   selectedStep,
 }) => {
-  let buttonType = formType == 'corner-modal' || 'large-modal' || 'modal' ? 'full-width' : 'inline'
+  const buttonType = formType === 'inline' ? 'inline' : 'full-width'
 
   return (
     <FormCTAContainer className={getClassName('formCTAContainer', appearance)}>

--- a/src/FrigadeForm/index.tsx
+++ b/src/FrigadeForm/index.tsx
@@ -9,7 +9,7 @@ import { CustomFormTypeProps } from './types'
 import { useTheme } from '../hooks/useTheme'
 import { FormContent } from './FormContent'
 
-export type FrigadeFormType = 'inline' | 'modal' | 'large-modal'
+export type FrigadeFormType = 'inline' | 'modal' | 'large-modal' | 'corner-modal'
 
 export interface FormProps extends DefaultFrigadeFlowProps {
   title?: string

--- a/src/FrigadeGuide/FrigadeGuide.tsx
+++ b/src/FrigadeGuide/FrigadeGuide.tsx
@@ -25,5 +25,5 @@ export const FrigadeGuide: FC<FrigadeGuideProps> = ({ flowId, style, appearance,
 
   const steps = getFlowSteps(flowId)
 
-  return <Guide steps={steps} style={style} {...props} />
+  return <Guide steps={steps} style={style} appearance={appearance} {...props} />
 }

--- a/src/FrigadeTour/index.tsx
+++ b/src/FrigadeTour/index.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useContext, useEffect } from 'react'
 import { useFlows } from '../api/flows'
-import { ToolTipProps, Tooltips } from '../Tooltips'
+import { ToolTipData, ToolTipProps, Tooltips } from '../Tooltips'
 import { StepData } from '../types'
 import { COMPLETED_FLOW } from '../api/common'
 import { Portal } from 'react-portal'
@@ -82,7 +82,7 @@ export const FrigadeTour: FC<ToolTipProps & { flowId: string; initialSelectedSte
   if (hasOpenModals()) {
     return null
   }
-  const steps = getFlowSteps(flowId)
+  const steps: ToolTipData[] = getFlowSteps(flowId)
 
   // Hide tour flow if another flow is open
   if (Object.keys(openFlowStates).length > 0) {

--- a/src/Guides/Guide.tsx
+++ b/src/Guides/Guide.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, FC } from 'react'
-import { Appearance, StepData } from '../types'
+import { Appearance, DefaultFrigadeFlowProps, StepData } from '../types'
 import { motion } from 'framer-motion'
 
 import {
@@ -21,13 +21,12 @@ export interface GuideStepData extends StepData {
   icon?: string
 }
 
-interface GuideProps {
+interface GuideProps extends Pick<DefaultFrigadeFlowProps, 'onButtonClick'> {
   steps: GuideStepData[]
   title: string
   style?: CSSProperties
   primaryColor?: string
   appearance: Appearance
-  onButtonClick?: (stepData: StepData) => void
 }
 
 /**

--- a/src/Tooltips/Tooltips.tsx
+++ b/src/Tooltips/Tooltips.tsx
@@ -24,7 +24,7 @@ const CARD_WIDTH = 385
 const CARD_HEIGHT = 50
 
 // TODO: Should extend from FlowItem in a shared types repo
-interface TooltipData extends StepData {
+export interface ToolTipData extends StepData {
   selector?: string
   subtitleStyle?: CSSProperties
   titleStyle?: CSSProperties
@@ -32,7 +32,7 @@ interface TooltipData extends StepData {
 }
 
 export interface ToolTipProps extends Omit<DefaultFrigadeFlowProps, 'flowId'> {
-  steps?: TooltipData[]
+  steps?: ToolTipData[]
   onDismiss?: () => void
   onComplete?: () => void
   tooltipPosition?: ToolTipPosition

--- a/src/Tooltips/Tooltips.tsx
+++ b/src/Tooltips/Tooltips.tsx
@@ -31,7 +31,7 @@ interface TooltipData extends StepData {
   buttonStyle?: CSSProperties
 }
 
-export interface ToolTipProps extends DefaultFrigadeFlowProps {
+export interface ToolTipProps extends Omit<DefaultFrigadeFlowProps, 'flowId'> {
   steps?: TooltipData[]
   onDismiss?: () => void
   onComplete?: () => void
@@ -52,6 +52,7 @@ export interface ToolTipProps extends DefaultFrigadeFlowProps {
    * Shows a close button in the top right corner of the tooltip. This will end the flow.
    */
   dismissible?: boolean
+  primaryColor?: string
 }
 
 const HighlightOuter = styled.div<{ primaryColor: string }>`
@@ -141,13 +142,13 @@ const Tooltips: FC<ToolTipProps> = ({
   showTooltipsSimultaneously = false,
   dismissible = false,
 }) => {
-  const [selfBounds, setSelfBounds] = useState<undefined | DOMRect>(undefined)
+  const [selfBounds, setSelfBounds] = useState<undefined | Partial<DOMRect>>(undefined)
   const [needsUpdate, setNeedsUpdate] = useState(new Date())
-  const selfRef = useRef()
+  const selfRef = useRef<HTMLDivElement>()
 
   const [elem, setElem] = useState(initialElem)
   const boundingRect = useElemRect(elem, needsUpdate)
-  const [lastBoundingRect, setLastBoundingRect] = useState()
+  const [lastBoundingRect, setLastBoundingRect] = useState<string>()
 
   useLayoutEffect(() => {
     if (selfRef.current) {

--- a/src/Tooltips/index.tsx
+++ b/src/Tooltips/index.tsx
@@ -1,2 +1,2 @@
 export { default as Tooltips } from './Tooltips'
-export type { ToolTipProps } from './Tooltips'
+export type { ToolTipData, ToolTipProps } from './Tooltips'

--- a/src/api/flows.ts
+++ b/src/api/flows.ts
@@ -96,7 +96,7 @@ export function useFlows() {
     return flow
   }
 
-  function getFlowSteps(flowId: string): any[] {
+  function getFlowSteps(flowId: string): StepData[] {
     if (!getFlow(flowId)) {
       return []
     }
@@ -110,7 +110,7 @@ export function useFlows() {
     const steps = JSON.parse(flowData)?.data ?? []
 
     return steps
-      .map((step: StepData, idx: number) => {
+      .map((step: StepData) => {
         const autoCalculatedProgress = getStepOptionalProgress(step)
         return {
           handleSecondaryButtonClick: () => {

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -86,7 +86,6 @@ interface ModalProps {
   headerContent?: React.ReactNode
   children: React.ReactNode
   style?: React.CSSProperties
-  closeTint?: string
   appearance?: Appearance
   dismissible?: boolean // defaults to true
 }

--- a/src/components/Progress/ProgressRing/ProgressRing.tsx
+++ b/src/components/Progress/ProgressRing/ProgressRing.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { motion } from 'framer-motion'
 
-const Circle: FC<{ color: string, percentage?: number, size: number, key: string}> = ({ color, percentage, size }) => {
+const Circle: FC<{ color: string, percentage?: number, size: number }> = ({ color, percentage, size }) => {
   const r = size * 0.5 - 2;
   const circum = 2 * Math.PI * r;
   const strokePct = ((1 - percentage) * circum); // where stroke will start, e.g. from 15% to 100%.

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -131,7 +131,7 @@ export interface DefaultFrigadeFlowProps {
   onButtonClick?: (
     step: StepData,
     index: number,
-    cta: 'primary' | 'secondary',
+    cta: 'primary' | 'secondary' | 'link',
     nextStep?: StepData
   ) => boolean
 }

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -170,6 +170,7 @@ export interface BaseTheme {
   fontSmoothing?: string
   fontWeight?: string | number
   borderRadius?: number
+  modalContainer?: CSSProperties
 }
 
 export const DefaultAppearance: Appearance = {

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -120,7 +120,7 @@ export interface DefaultFrigadeFlowProps {
    * @param step
    * @param index
    */
-  onStepCompletion?: (step: StepData, index: number, nextStep?: StepData, data?: any) => boolean
+  onStepCompletion?: (step: StepData, index: number, nextStep?: StepData, data?: any, stepData?: object) => boolean
   /**
    * Handler for when a primary or secondary CTA is clicked (regardless if step is completed or not).
    * Return true if your app performs an action (e.g. open other modal or page transition).

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -134,6 +134,9 @@ export interface DefaultFrigadeFlowProps {
     cta: 'primary' | 'secondary' | 'link',
     nextStep?: StepData
   ) => boolean
+
+  onDismiss?: () => void
+  onComplete?: () => void
 }
 
 export interface Appearance {

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -130,8 +130,8 @@ export interface DefaultFrigadeFlowProps {
    */
   onButtonClick?: (
     step: StepData,
-    index: number,
-    cta: 'primary' | 'secondary' | 'link',
+    index?: number,
+    cta?: 'primary' | 'secondary' | 'link',
     nextStep?: StepData
   ) => boolean
 


### PR DESCRIPTION
In the grand tradition of yak shaving:
1. I'm finishing up the standalone wrapper for the sdk
2. ...and I want to `npm-link` and include the sdk into another local package for testing
3. ...and in order to do that, I need to run `yarn build` locally
4. ...and in order for the build to succeed, I need all existing TypeScript errors resolved.

Caveat: I'm still familiarizing myself with much of this code and I don't _think_ this will have broken anything, since any breakage should show up in the form of red underlines from the TypeScript compiler.

If there's a test instance with every component spun up in it where I can visually check everything lmk. If not, this might be the point where Storybook gets thrown in the SDK backlog 👀 