### PR TITLE
fix: memoize functions to prevent useless rerenders

### DIFF
--- a/src/api/flow-responses.ts
+++ b/src/api/flow-responses.ts
@@ -31,7 +31,6 @@ export interface PublicStepState {
 
 export function useFlowResponses() {
   const { config } = useConfig()
-  const { userId, setUserId, organizationId } = useContext(FrigadeContext)
   const { userFlowStatesData } = useUserFlowStates()
   const { failedFlowResponses, setFailedFlowResponses, flowResponses, setFlowResponses } =
     useContext(FrigadeContext)

--- a/src/api/organizations.tsx
+++ b/src/api/organizations.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react'
+import React, { useCallback, useContext, useEffect } from 'react'
 import { FrigadeContext } from '../FrigadeProvider'
 import { API_PREFIX, useConfig } from './common'
 import { useUserFlowStates } from './user-flow-states'
@@ -45,50 +45,58 @@ export function useOrganization() {
     }
   }, [userId, organizationId])
 
-  async function addPropertiesToOrganization(properties: EntityProperties) {
-    if (!organizationId || !userId) {
-      console.error(
-        'Cannot add properties to organization: Organization ID and User ID must both be set.'
-      )
-      return
-    }
+  const addPropertiesToOrganization = useCallback(
+    async (properties: EntityProperties) => {
+      if (!organizationId || !userId) {
+        console.error(
+          'Cannot add properties to organization: Organization ID and User ID must both be set.',
+          { organizationId, userId }
+        )
+        return
+      }
 
-    const data: AddPropertyToOrganizationDTO = {
-      foreignUserId: userId,
-      foreignUserGroupId: organizationId,
-      properties,
-    }
-    await fetch(`${API_PREFIX}userGroups`, {
-      ...config,
-      method: 'POST',
-      body: JSON.stringify(data),
-    })
-    mutateUserFlowState()
-  }
+      const data: AddPropertyToOrganizationDTO = {
+        foreignUserId: userId,
+        foreignUserGroupId: organizationId,
+        properties,
+      }
+      await fetch(`${API_PREFIX}userGroups`, {
+        ...config,
+        method: 'POST',
+        body: JSON.stringify(data),
+      })
+      mutateUserFlowState()
+    },
+    [organizationId, userId, config, mutateUserFlowState]
+  )
 
-  async function trackEventForOrganization(event: string, properties?: EntityProperties) {
-    if (!organizationId || !userId) {
-      console.error(
-        'Cannot track event for organization: Organization ID and User ID must both be set.'
-      )
-      return
-    }
-    const eventData: OrganizationEvent = {
-      event,
-      properties,
-    }
-    const data: AddPropertyToOrganizationDTO = {
-      foreignUserId: userId,
-      foreignUserGroupId: organizationId,
-      events: [eventData],
-    }
-    await fetch(`${API_PREFIX}userGroups`, {
-      ...config,
-      method: 'POST',
-      body: JSON.stringify(data),
-    })
-    mutateUserFlowState()
-  }
+  const trackEventForOrganization = useCallback(
+    async (event: string, properties?: EntityProperties) => {
+      if (!organizationId || !userId) {
+        console.error(
+          'Cannot track event for organization: Organization ID and User ID must both be set.',
+          { organizationId, userId }
+        )
+        return
+      }
+      const eventData: OrganizationEvent = {
+        event,
+        properties,
+      }
+      const data: AddPropertyToOrganizationDTO = {
+        foreignUserId: userId,
+        foreignUserGroupId: organizationId,
+        events: [eventData],
+      }
+      await fetch(`${API_PREFIX}userGroups`, {
+        ...config,
+        method: 'POST',
+        body: JSON.stringify(data),
+      })
+      mutateUserFlowState()
+    },
+    [organizationId, userId, config, mutateUserFlowState]
+  )
 
   return {
     organizationId,


### PR DESCRIPTION
If I'm using strict eslint rules for hooks, then I need to add `addPropertiesToUser` to deps.
But once you call `addPropertiesToUser()`, then hook `useFrigadeUser` will initiate render and there will be a new function `addPropertiesToUser` created, that will call `useEffect` again and it will be an infinite loop.
```js
const { addPropertiesToUser } = useFrigadeUser()

useEffect(() => {
    addPropertiesToUser({ firstName: user.firstName })
}, [user, addPropertiesToUser])
```

So, I memoized such functions with `useCallback`.