### PR TITLE
fix: update context on props change

### DIFF
--- a/src/FrigadeProvider/index.tsx
+++ b/src/FrigadeProvider/index.tsx
@@ -121,6 +121,18 @@ export const FrigadeProvider: FC<FrigadeProviderProps> = ({
   }
 
   useEffect(() => {
+    if (userId) {
+      setUserIdValue(userId)
+    }
+  }, [userId])
+
+  useEffect(() => {
+    if (organizationId) {
+      setOrganizationIdValue(organizationId)
+    }
+  }, [organizationId])
+
+  useEffect(() => {
     if (!publicApiKey) {
       console.error('FrigadeProvider: publicApiKey is required')
     }


### PR DESCRIPTION
Simple example:
```jsx
function Wrapper({ user }: { user?: IUser | null }) {
  return (
    <FrigadeProvider
      publicApiKey={process.env.REACT_APP_FRIGADE_PUBLIC_API_KEY ?? ''}
      userId={user?.id}
      organizationId={user?.organizationId}
    >
      <App />
    </FrigadeProvider>
  );
}
```

There might be cases when there is no `userId` or `organizationId` on first render, but it will be later.
So, it is better to update state/context after props change.