### PR TITLE
Better Graceful degradation

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "dompurify": "^3.0.1",
     "framer-motion": "6.5.0",
     "react-dom": "17.0.2",
+    "react-error-boundary": "^4.0.4",
     "react-portal": "^4.2.2",
     "styled-components": "5.3.6",
     "swr": "^2.0.3",

--- a/src/FrigadeProvider/index.tsx
+++ b/src/FrigadeProvider/index.tsx
@@ -4,6 +4,7 @@ import { DataFetcher } from '../components/DataFetcher'
 import { Flow } from '../api/flows'
 import { FlowResponse } from '../api/flow-responses'
 import { Appearance, DefaultAppearance } from '../types'
+import { ErrorBoundary } from 'react-error-boundary'
 
 export interface IFrigadeContext {
   publicApiKey: string
@@ -154,37 +155,39 @@ export const FrigadeProvider: FC<FrigadeProviderProps> = ({
   }, [publicApiKey])
 
   return (
-    <FrigadeContext.Provider
-      value={{
-        publicApiKey,
-        userId: userIdValue,
-        setUserId: setUserIdValue,
-        setFlows,
-        flows: flows,
-        failedFlowResponses,
-        setFailedFlowResponses,
-        flowResponses,
-        setFlowResponses,
-        userProperties,
-        setUserProperties,
-        openFlowStates,
-        setOpenFlowStates,
-        customVariables,
-        setCustomVariables,
-        isNewGuestUser,
-        setIsNewGuestUser,
-        hasActiveFullPageFlow,
-        setHasActiveFullPageFlow,
-        organizationId: organizationIdValue,
-        setOrganizationId: setOrganizationIdValue,
-        navigate: config && config.navigate ? config.navigate : internalNavigate,
-        defaultAppearance: appearance,
-      }}
-    >
-      <ThemeProvider theme={appearance.theme}>
-        {children}
-        <DataFetcher />
-      </ThemeProvider>
-    </FrigadeContext.Provider>
+    <ErrorBoundary fallback={<>{children}</>}>
+      <FrigadeContext.Provider
+        value={{
+          publicApiKey,
+          userId: userIdValue,
+          setUserId: setUserIdValue,
+          setFlows,
+          flows: flows,
+          failedFlowResponses,
+          setFailedFlowResponses,
+          flowResponses,
+          setFlowResponses,
+          userProperties,
+          setUserProperties,
+          openFlowStates,
+          setOpenFlowStates,
+          customVariables,
+          setCustomVariables,
+          isNewGuestUser,
+          setIsNewGuestUser,
+          hasActiveFullPageFlow,
+          setHasActiveFullPageFlow,
+          organizationId: organizationIdValue,
+          setOrganizationId: setOrganizationIdValue,
+          navigate: config && config.navigate ? config.navigate : internalNavigate,
+          defaultAppearance: appearance,
+        }}
+      >
+        <ThemeProvider theme={appearance.theme}>
+          {children}
+          <DataFetcher />
+        </ThemeProvider>
+      </FrigadeContext.Provider>
+    </ErrorBoundary>
   )
 }

--- a/src/api/flow-responses.ts
+++ b/src/api/flow-responses.ts
@@ -4,11 +4,11 @@ import {
   API_PREFIX,
   COMPLETED_FLOW,
   COMPLETED_STEP,
-  gracefullyFetch,
   NOT_STARTED_FLOW,
   STARTED_FLOW,
   STARTED_STEP,
   useConfig,
+  useGracefulFetch,
 } from './common'
 import { FrigadeContext } from '../FrigadeProvider'
 import { useUserFlowStates } from './user-flow-states'
@@ -42,6 +42,7 @@ export function useFlowResponses() {
   const [successfulFlowResponses, setSuccessfulFlowResponses] = useState<Set<FlowResponse>>(
     new Set()
   )
+  const gracefullyFetch = useGracefulFetch()
 
   function postFlowResponse(flowResponse: FlowResponse) {
     const flowResponseString = JSON.stringify(flowResponse)

--- a/src/api/flows.ts
+++ b/src/api/flows.ts
@@ -64,13 +64,18 @@ export function useFlows() {
   }
   const { addResponse, getFlowResponses } = useFlowResponses()
   const fetcher = (url) =>
-    fetch(url, config).then((response) => {
-      if (response.ok) {
-        return response.json()
-      }
-      console.error(`Error fetching ${url} (${response.status}): ${response.statusText}`)
-      return emptyResponse
-    })
+    fetch(url, config)
+      .then((response) => {
+        if (response.ok) {
+          return response.json()
+        }
+        console.error(`Error fetching ${url} (${response.status}): ${response.statusText}`)
+        return emptyResponse
+      })
+      .catch((error) => {
+        console.error(`Error fetching ${url}: ${error}`)
+        return emptyResponse
+      })
   const {
     userFlowStatesData,
     isLoadingUserFlowStateData,

--- a/src/api/organizations.tsx
+++ b/src/api/organizations.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect } from 'react'
 import { FrigadeContext } from '../FrigadeProvider'
-import { API_PREFIX, gracefullyFetch, useConfig } from './common'
+import { API_PREFIX, useConfig, useGracefulFetch } from './common'
 import { useUserFlowStates } from './user-flow-states'
 import { GUEST_PREFIX } from './users'
 import { EntityProperties } from '../FrigadeForm/types'
@@ -21,6 +21,7 @@ export function useOrganization() {
   const { organizationId, userId, setOrganizationId } = useContext(FrigadeContext)
   const { mutateUserFlowState } = useUserFlowStates()
   const { config } = useConfig()
+  const gracefullyFetch = useGracefulFetch()
 
   useEffect(() => {
     // Check if user is not a guest

--- a/src/api/user-flow-states.ts
+++ b/src/api/user-flow-states.ts
@@ -38,12 +38,17 @@ export function useUserFlowStates(): {
     })),
   }
   const fetcher = (url) =>
-    fetch(url, config).then((response) => {
-      if (response.ok) {
-        return response.json()
-      }
-      throw new Error('Failed to fetch user flow states')
-    })
+    fetch(url, config)
+      .then((response) => {
+        if (response.ok) {
+          return response.json()
+        }
+        throw new Error('Failed to fetch user flow states')
+      })
+      .catch((error) => {
+        console.error(`Error fetching ${url}: ${error}`)
+        return emptyResponse
+      })
 
   const {
     data,

--- a/src/api/users.tsx
+++ b/src/api/users.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect } from 'react'
 import { FrigadeContext } from '../FrigadeProvider'
-import { API_PREFIX, gracefullyFetch, useConfig } from './common'
+import { API_PREFIX, useConfig, useGracefulFetch } from './common'
 import { useUserFlowStates } from './user-flow-states'
 import { EntityProperties } from '../FrigadeForm/types'
 
@@ -21,6 +21,7 @@ export function useUser() {
   const { userId, organizationId, setUserId, setUserProperties } = useContext(FrigadeContext)
   const { config } = useConfig()
   const { mutateUserFlowState } = useUserFlowStates()
+  const gracefullyFetch = useGracefulFetch()
   // Use local storage to mark if user has already been registered in frigade
   useEffect(() => {
     // Check if user is not a guest

--- a/yarn.lock
+++ b/yarn.lock
@@ -10505,6 +10505,13 @@ react-element-to-jsx-string@^15.0.0:
     is-plain-object "5.0.0"
     react-is "18.1.0"
 
+react-error-boundary@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.4.tgz#d2e84505b0a67cec7a6bf33b0146faadfe31597d"
+  integrity sha512-AbqMFx8bCsob8rCHZvJYQ42MQijK0/034RUvan9qrqyJCpazr8d9vKHrysbxcr6odoHLZvQEcYomFPoIqH9fow==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-inspector@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-6.0.1.tgz#1a37f0165d9df81ee804d63259eaaeabe841287d"


### PR DESCRIPTION
Adds a error boundary where we try to achieve the following:
 - In the case of any API failures to Frigade, we simply hide Frigade from the session.
 - Errors still get logged in the console but don't catch on to any other error boundaries.