### PR TITLE
FRI-385 Multi-step announcement w/ pagination

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -1,0 +1,16 @@
+{
+  "sourceType": "unambiguous",
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "chrome": 100
+        }
+      }
+    ],
+    "@babel/preset-typescript",
+    "@babel/preset-react"
+  ],
+  "plugins": []
+}

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   "devDependencies": {
     "@babel/core": "^7.15.8",
     "@babel/plugin-transform-runtime": "^7.19.6",
-    "@babel/preset-env": "^7.20.2",
+    "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",
-    "@babel/preset-typescript": "^7.18.6",
+    "@babel/preset-typescript": "^7.21.5",
     "@storybook/addon-essentials": "^7.0.9",
     "@storybook/addon-interactions": "^7.0.9",
     "@storybook/addon-links": "^7.0.9",

--- a/src/FrigadeForm/FormPagination.tsx
+++ b/src/FrigadeForm/FormPagination.tsx
@@ -1,0 +1,50 @@
+import React, { FC } from 'react'
+import styled from 'styled-components'
+
+import { useTheme } from '../hooks/useTheme'
+import { Appearance } from '../types'
+
+const Wrapper = styled.div`
+  text-align: center;
+`
+
+interface FormPaginationProps {
+  stepCount: number
+  currentStep: number
+  appearance: Appearance
+  className?: string
+}
+
+export const FormPagination: FC<FormPaginationProps> = ({
+  stepCount = 0,
+  currentStep = 0,
+  className,
+  appearance,
+}) => {
+  const { theme } = useTheme().mergeAppearanceWithDefault(appearance)
+
+  return (
+    <Wrapper className={className}>
+      <svg
+        width={16 * stepCount - 8}
+        height={8}
+        viewBox={`0 0 ${16 * stepCount - 8} 8`}
+        fill="none"
+      >
+        {Array(stepCount)
+          .fill(null)
+          .map((_, idx) => (
+            <rect
+              key={idx}
+              x={16 * idx}
+              y={0}
+              width={8}
+              height={8}
+              rx={4}
+              fill={currentStep === idx ? theme.colorPrimary : '#E6E6E6'}
+            />
+          ))}
+      </svg>
+    </Wrapper>
+  )
+}

--- a/src/FrigadeForm/__stories__/FrigadeForm.stories.tsx
+++ b/src/FrigadeForm/__stories__/FrigadeForm.stories.tsx
@@ -1,0 +1,15 @@
+import { FrigadeForm } from '../index'
+
+export default {
+  title: 'Form',
+  component: FrigadeForm,
+}
+
+export const Announcement = {
+  args: {
+    flowId: 'flow_qmd7eFmco9aTJmf8',
+    type: 'modal',
+    modalPosition: 'center',
+    showPagination: true,
+  },
+}

--- a/src/FrigadeForm/index.tsx
+++ b/src/FrigadeForm/index.tsx
@@ -24,6 +24,7 @@ export interface FormProps extends DefaultFrigadeFlowProps {
   repeatable?: boolean
   endFlowOnDismiss?: boolean
   modalPosition?: ModalPosition
+  showPagination?: boolean
 }
 
 export const FrigadeForm: FC<FormProps> = ({
@@ -43,6 +44,7 @@ export const FrigadeForm: FC<FormProps> = ({
   modalPosition = 'center',
   repeatable = false,
   onDismiss,
+  showPagination = false,
 }) => {
   const {
     getFlow,
@@ -145,6 +147,7 @@ export const FrigadeForm: FC<FormProps> = ({
           setVisible={setVisible}
           setShowModal={setShowModal}
           onDismiss={onDismiss}
+          showPagination={showPagination}
         />
       </Modal>
     )
@@ -169,6 +172,7 @@ export const FrigadeForm: FC<FormProps> = ({
           setVisible={setVisible}
           setShowModal={setShowModal}
           onDismiss={onDismiss}
+          showPagination={showPagination}
         />
       </CornerModal>
     )
@@ -192,6 +196,7 @@ export const FrigadeForm: FC<FormProps> = ({
         setVisible={setVisible}
         setShowModal={setShowModal}
         onDismiss={onDismiss}
+        showPagination={showPagination}
       />{' '}
     </>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,7 +173,7 @@
     lru-cache "^5.1.1"
     semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.20.12", "@babel/helper-create-class-features-plugin@^7.20.5", "@babel/helper-create-class-features-plugin@^7.20.7":
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.20.5", "@babel/helper-create-class-features-plugin@^7.20.7":
   version "7.20.12"
   resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz"
   integrity sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==
@@ -1169,15 +1169,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.9"
 
-"@babel/plugin-transform-typescript@^7.18.6":
-  version "7.20.13"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.13.tgz"
-  integrity sha512-O7I/THxarGcDZxkgWKMUrk7NK1/WbHAg3Xx86gqS6x9MTrNL6AwIluuZ96ms4xeDe6AVx6rjHbWHP7x26EPQBA==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.20.12"
-    "@babel/helper-plugin-utils" "^7.20.2"
-    "@babel/plugin-syntax-typescript" "^7.20.0"
-
 "@babel/plugin-transform-typescript@^7.21.3":
   version "7.21.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.21.3.tgz#316c5be579856ea890a57ebc5116c5d064658f2b"
@@ -1291,7 +1282,7 @@
     core-js-compat "^3.25.1"
     semver "^6.3.0"
 
-"@babel/preset-env@~7.21.0":
+"@babel/preset-env@^7.21.5", "@babel/preset-env@~7.21.0":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.21.5.tgz#db2089d99efd2297716f018aeead815ac3decffb"
   integrity sha512-wH00QnTTldTbf/IefEVyChtRdw5RJvODT/Vb4Vcxq1AZvtXj6T0YeX0cAcXhI6/BdGuiP3GcNIL4OQbI2DVNxg==
@@ -1395,7 +1386,7 @@
 
 "@babel/preset-react@^7.18.6":
   version "7.18.6"
-  resolved "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.18.6.tgz"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.18.6.tgz#979f76d6277048dc19094c217b507f3ad517dd2d"
   integrity sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
@@ -1405,7 +1396,7 @@
     "@babel/plugin-transform-react-jsx-development" "^7.18.6"
     "@babel/plugin-transform-react-pure-annotations" "^7.18.6"
 
-"@babel/preset-typescript@^7.13.0":
+"@babel/preset-typescript@^7.13.0", "@babel/preset-typescript@^7.21.5":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.21.5.tgz#68292c884b0e26070b4d66b202072d391358395f"
   integrity sha512-iqe3sETat5EOrORXiQ6rWfoOg2y68Cs75B9wNxdPW4kixJxh7aXQE1KPdWLDniC24T/6dSnguF33W9j/ZZQcmA==
@@ -1415,15 +1406,6 @@
     "@babel/plugin-syntax-jsx" "^7.21.4"
     "@babel/plugin-transform-modules-commonjs" "^7.21.5"
     "@babel/plugin-transform-typescript" "^7.21.3"
-
-"@babel/preset-typescript@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz"
-  integrity sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.18.6"
-    "@babel/helper-validator-option" "^7.18.6"
-    "@babel/plugin-transform-typescript" "^7.18.6"
 
 "@babel/register@^7.13.16":
   version "7.21.0"


### PR DESCRIPTION
**Changelog:**
- Added pagination for multi-step announcements
- Refactored FormContent a bit to tidy up how it wraps itself in animations for `large-modal`
- Added a basic shell to Storybook for testing Announcements.
- Added a babel config for Storybook v7 (they dropped default configs in this version, so we have to provide our own)